### PR TITLE
Switch to shared ONNX Runtime library (.so) in build config.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ if (UNIX AND NOT APPLE)
     endif ()
 
     include_directories(${ONNXRUNTIME_DIR}/include)
-    set(ONNXRUNTIME_LIB ${ONNXRUNTIME_DIR}/lib/libonnxruntime.a)
+    set(ONNXRUNTIME_LIB ${ONNXRUNTIME_DIR}/lib/libonnxruntime.so)
 
     target_link_libraries(${EXTENSION_NAME}
             ${ONNXRUNTIME_LIB}


### PR DESCRIPTION
Updated the build configuration to use the shared ONNX Runtime library (`.so`) instead of the static library (`.a`). This change improves modularity and reduces binary size, enabling dynamic loading of the library at runtime.